### PR TITLE
feat: add styling on side tab scrollbar & center buttons

### DIFF
--- a/src/style/global.js
+++ b/src/style/global.js
@@ -264,6 +264,10 @@ export const GlobalStyles = createGlobalStyle`
     margin-right: auto;
     width: 8em
   }
+  .restart-button button:hover{
+    transform:scale(1.18);
+    transition:0.3s;
+  }
   .alert{
     opacity: 0.3;
     background-image: ${({ theme }) => theme.gradient};
@@ -615,15 +619,27 @@ export const GlobalStyles = createGlobalStyle`
     text-align: left;
     margin-top: 10px;
   }
+  .Catalog::-webkit-scrollbar{
+    width:5px;
+  }
+  .Catalog::-webkit-scrollbar-track{
+    background:transparent;
+  }
+  .Catalog::-webkit-scrollbar-thumb{
+    background:${({ theme }) => theme.stats};
+    border-radius:12px;
+  }
   .Catalog-title{
     margin-top: 20px;
     margin-bottom: 10px;
   }
   .Catalog-li{
+    cursor:pointer;
     margin-bottom: 10px;
     color: ${({ theme }) => theme.textTypeBox};
   }
   .Catalog-li-Activated{
+    cursor:default;
     margin-bottom: 10px;
     color: ${({ theme }) => theme.stats};
   }


### PR DESCRIPTION
add some styling on dictionary's choosen bar and center buttons, belows are compared image.

![side-tab-before](https://user-images.githubusercontent.com/30712768/192085790-45f7295c-adc7-407c-bdd6-ae6df69699a4.gif)
side-tab before

![side-tab-after](https://user-images.githubusercontent.com/30712768/192085807-deba516c-20ca-4543-a383-4e10c4794a51.gif)
side-tab after

![center-buttons-before](https://user-images.githubusercontent.com/30712768/192085820-65549347-0e17-484f-92bb-e9ad7b68ccf0.gif)
center-buttons before

![center-buttons-after](https://user-images.githubusercontent.com/30712768/192085830-21e3abba-d8b9-4923-a6ee-1958a7882b9d.gif)
center-buttons after